### PR TITLE
add packit config for packaging CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,37 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration
+
+specfile_path: fb303.spec
+
+upstream_package_name: fb303
+downstream_package_name: fb303
+
+actions:
+  post-upstream-clone: "bash -c \"git clone -b packit https://pagure.io/meta/fb303.git fb303-dist-git && mv fb303-dist-git/fb303*.{spec,patch} . || true\""
+
+jobs:
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+    - fedora-development-aarch64
+    - fedora-development-armhfp
+    - fedora-development-i386
+    - fedora-development-x86_64
+    - fedora-35-aarch64
+    - fedora-35-armhfp
+    - fedora-35-i386
+    - fedora-35-x86_64
+
+- job: copr_build
+  trigger: release
+  metadata:
+    targets:
+    - fedora-development-aarch64
+    - fedora-development-armhfp
+    - fedora-development-i386
+    - fedora-development-x86_64
+    - fedora-35-aarch64
+    - fedora-35-armhfp
+    - fedora-35-i386
+    - fedora-35-x86_64


### PR DESCRIPTION
Summary:
Configure so every tag and PR trigger a build on Fedora. The build won't be
pushed out, it's just to test compilation on alternate compilers (GCC,
clang-with-gcc-libstdc++) and architectures (ARM 32- and 64-bit, x86).

Differential Revision: D34769708

