### PR TITLE
Delete default ctor of BasicQuantileStat::SlidingWindowEstimate and add new ctor

### DIFF
--- a/fb303/QuantileStat-inl.h
+++ b/fb303/QuantileStat-inl.h
@@ -61,10 +61,10 @@ BasicQuantileStat<ClockT>::getEstimates(
 
   estimates.slidingWindows.reserve(slidingWindowVec_.size());
   for (auto& slidingWindow : slidingWindowVec_) {
-    auto& swe = estimates.slidingWindows.emplace_back();
-    swe.windowLength = slidingWindow.windowLength;
-    swe.nWindows = slidingWindow.nWindows;
-    swe.estimate = slidingWindow.estimator.estimateQuantiles(quantiles, now);
+    estimates.slidingWindows.emplace_back(
+        slidingWindow.estimator.estimateQuantiles(quantiles, now),
+        slidingWindow.windowLength,
+        slidingWindow.nWindows);
   }
   return estimates;
 }

--- a/fb303/QuantileStat.h
+++ b/fb303/QuantileStat.h
@@ -40,6 +40,13 @@ class BasicQuantileStat {
 
   struct SlidingWindowEstimate {
    public:
+    SlidingWindowEstimate() = delete;
+    SlidingWindowEstimate(
+        folly::QuantileEstimates&& e,
+        std::chrono::seconds wl,
+        size_t n)
+        : estimate(std::move(e)), windowLength(wl), nWindows(n) {}
+
     folly::QuantileEstimates estimate;
     std::chrono::seconds windowLength;
     size_t nWindows;


### PR DESCRIPTION
Summary: This commit deletes the default constructor of BasicQuantileStat::SlidingWindowEstimate and replaces it with a constructor that takes its necessary data as by-value arguments

Reviewed By: yfeldblum, r-barnes

Differential Revision: D36866405

