### PR TITLE
getdeps: support GETDEPS_WGET_ARGS in wget version

### DIFF
--- a/build/fbcode_builder/getdeps/fetcher.py
+++ b/build/fbcode_builder/getdeps/fetcher.py
@@ -683,15 +683,18 @@ def download_url_to_file_with_progress(url: str, file_name) -> None:
     start = time.time()
     try:
         if os.environ.get("GETDEPS_USE_WGET") is not None:
-            subprocess.run(
+            procargs = (
                 [
                     "wget",
+                ]
+                + os.environ.get("GETDEPS_WGET_ARGS", "").split()
+                + [
                     "-O",
                     file_name,
                     url,
                 ]
             )
-
+            subprocess.run(procargs, capture_output=True)
             headers = None
 
         elif os.environ.get("GETDEPS_USE_LIBCURL") is not None:

--- a/build/fbcode_builder/manifests/xz
+++ b/build/fbcode_builder/manifests/xz
@@ -11,12 +11,12 @@ xz
 xz-devel
 
 [download]
-url = https://tukaani.org/xz/xz-5.2.5.tar.gz
-sha256 = f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10
+url = https://github.com/tukaani-project/xz/releases/download/v5.4.6/xz-5.4.6.tar.gz
+sha256 = aeba3e03bf8140ddedf62a0a367158340520f6b384f75ca6045ccc6c0d43fd5c
 
 [build]
 builder = autoconf
-subdir = xz-5.2.5
+subdir = xz-5.4.6
 
 [autoconf.args]
 --disable-shared


### PR DESCRIPTION
Summary: I found it useful to be able to set `GETDEPS_WGET_ARGS` to change some of the flags to `wget` while it's in that fetch mode :)

Differential Revision: D56263907


