### PR TITLE
ExportedHistogramMap::addHistogram - no pointer

### DIFF
--- a/fb303/ExportedHistogramMap.cpp
+++ b/fb303/ExportedHistogramMap.cpp
@@ -89,17 +89,13 @@ ExportedHistogramMap::HistogramPtr ExportedHistogramMap::getOrCreateUnlocked(
 
 bool ExportedHistogramMap::addHistogram(
     StringPiece name,
-    const ExportedHistogram* copyMe) {
+    const ExportedHistogram& copyMe) {
   // Call getOrCreateUnlocked() to do all of the work.
   bool created;
-  auto item = getOrCreateUnlocked(name, copyMe, &created);
-  if (!created && copyMe) {
+  auto item = getOrCreateUnlocked(name, &copyMe, &created);
+  if (!created) {
     checkAdd(
-        name,
-        item,
-        copyMe->getBucketSize(),
-        copyMe->getMin(),
-        copyMe->getMax());
+        name, item, copyMe.getBucketSize(), copyMe.getMin(), copyMe.getMax());
   }
   return created;
 }

--- a/fb303/ExportedHistogramMap.h
+++ b/fb303/ExportedHistogramMap.h
@@ -171,9 +171,7 @@ class ExportedHistogramMap {
    * Then, all of the histogram's levels are all exported to DynamicStrings
    * with keys of the form:   <histogram_name>.hist.<level_duration>
    */
-  bool addHistogram(
-      folly::StringPiece name,
-      const ExportedHistogram* copyMe = nullptr);
+  bool addHistogram(folly::StringPiece name, const ExportedHistogram& copyMe);
 
   bool addHistogram(
       folly::StringPiece name,

--- a/fb303/ServiceData.cpp
+++ b/fb303/ServiceData.cpp
@@ -160,7 +160,7 @@ void ServiceData::addStatExports(
             max,
             statPrototype != nullptr ? *statPrototype
                                      : histMap_.getDefaultStat());
-        histMap_.addHistogram(key, &hist);
+        histMap_.addHistogram(key, hist);
         addedHist = true;
       }
       exportHistogramPercentile(key, folly::to<int32_t>(stat));
@@ -202,7 +202,7 @@ bool ServiceData::addHistogram(
 }
 
 bool ServiceData::addHistogram(StringPiece key, const ExportedHistogram& hist) {
-  return histMap_.addHistogram(key, &hist);
+  return histMap_.addHistogram(key, hist);
 }
 
 void ServiceData::exportHistogramPercentile(StringPiece key, int pct) {

--- a/fb303/test/ExportedHistogramTest.cpp
+++ b/fb303/test/ExportedHistogramTest.cpp
@@ -38,10 +38,10 @@ TEST(ExportedHistogram, ExportedStats) {
   ExportedHistogram defaultHistogram(10, 0, 10000);
   ExportedHistogramMapImpl histMap(&counters, &strings, defaultHistogram);
 
-  histMap.addHistogram("hist1");
+  histMap.addHistogram("hist1", defaultHistogram);
   histMap.exportPercentile("hist1", 50, 95, 99, 100);
   histMap.exportStat("hist1", COUNT, SUM, AVG, RATE);
-  histMap.addHistogram("hist2");
+  histMap.addHistogram("hist2", defaultHistogram);
   histMap.exportPercentile("hist2", 50, 95, 99, 100);
   histMap.exportStat("hist2", COUNT, SUM, AVG, RATE);
   // hist3 is similar to hist1 but has buckets 5x as wide


### PR DESCRIPTION
Summary: the nullptr overload isn't needed

Differential Revision: D61146186
