### PR TITLE
fix(oss): fb303_thrift -> fb303_core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ target_include_directories(fb303 PUBLIC
 )
 
 target_link_libraries(fb303
-  fb303_thrift_cpp
+  fb303_core_cpp
   Folly::folly
   FBThrift::thrift
 )

--- a/fb303/thrift/CMakeLists.txt
+++ b/fb303/thrift/CMakeLists.txt
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 if (PYTHON_EXTENSIONS)
-  set(FB303_LANG cpp py)
+  set(FB303_LANG cpp py py3)
 else ()
   set(FB303_LANG cpp)
 endif ()
 
 add_fbthrift_library(
-  fb303_thrift
+  fb303_core
   fb303_core.thrift
   LANGUAGES ${FB303_LANG}
   THRIFT_INCLUDE_DIR "${INCLUDE_INSTALL_DIR}/thrift-files"
@@ -27,30 +27,36 @@ add_fbthrift_library(
     BaseService
 )
 if (BUILD_SHARED_LIBS)
-  set_property(TARGET fb303_thrift_cpp PROPERTY VERSION ${PACKAGE_VERSION})
+  set_property(TARGET fb303_core_cpp PROPERTY VERSION ${PACKAGE_VERSION})
 endif ()
 
 install(
-  TARGETS fb303_thrift_cpp
+  TARGETS fb303_core_cpp
   EXPORT fb303-exports
   LIBRARY DESTINATION "${LIB_INSTALL_DIR}"
   ARCHIVE DESTINATION "${LIB_INSTALL_DIR}"
   PUBLIC_HEADER DESTINATION
-    "$<TARGET_PROPERTY:fb303_thrift_cpp,HEADER_INSTALL_DIR>"
+    "$<TARGET_PROPERTY:fb303_core_cpp,HEADER_INSTALL_DIR>"
 )
 install(
-  TARGETS fb303_thrift_cpp.thrift_includes
+  TARGETS fb303_core_cpp.thrift_includes
   EXPORT fb303-exports
 )
 install(
   FILES fb303_core.thrift
-  DESTINATION "$<TARGET_PROPERTY:fb303_thrift_cpp,THRIFT_INSTALL_DIR>"
+  DESTINATION "$<TARGET_PROPERTY:fb303_core_cpp,THRIFT_INSTALL_DIR>"
 )
 
 if (PYTHON_EXTENSIONS)
-  install_fb_python_library(fb303_thrift_py EXPORT fb303-exports)
+  install_fb_python_library(fb303_core_py EXPORT fb303-exports)
   install(
-    TARGETS fb303_thrift_py.thrift_includes
+    TARGETS fb303_core_py.thrift_includes
+    EXPORT fb303-exports
+  )
+
+  install_fb_python_library(fb303_core_py3 EXPORT fb303-exports)
+  install(
+    TARGETS fb303_core_py3.thrift_includes
     EXPORT fb303-exports
   )
 endif ()


### PR DESCRIPTION
This diff aligns the OSS target naming with that in the internal BUCK build, enabling fb303 to build with PYTHON_EXTENSIONS enabled as well as clearing the way for other projects which depend on this one.

Additionally, this change enables the "py3" thrift generator to run, which is required by other Meta OSS projects.

Test:
This change has been tested by running a full build of EdenFS in the sapling project, pinned to this revision. (There are other changes to folly, fbthrift, rust-common, as well as sapling necessary to get a green build, but this a step on that path.)