### PR TITLE
Fix TimeseriesExporter duration_cast namespace issue

### DIFF
--- a/fb303/TimeseriesExporter.h
+++ b/fb303/TimeseriesExporter.h
@@ -19,6 +19,7 @@
 #include <fb303/ExportType.h>
 #include <fb303/MutexWrapper.h>
 #include <fb303/Timeseries.h>
+#include <chrono>
 
 namespace facebook::fb303 {
 
@@ -95,8 +96,8 @@ class TimeseriesExporter {
       // typical name: 'ad_request.rate.600' or
       // 'ad_request_elapsed_time.avg.3600'
       auto duration = stat->getLevel(level).duration();
-      auto durationSecs = duration_cast<std::chrono::seconds>(duration);
-      DCHECK(duration_cast<typename MLTS::Duration>(durationSecs) == duration);
+      auto durationSecs = std::chrono::duration_cast<std::chrono::seconds>(duration);
+      DCHECK(std::chrono::duration_cast<typename MLTS::Duration>(durationSecs) == duration);
       snprintf(
           counterName,
           counterNameSize,


### PR DESCRIPTION
fixes the following compilation errors in edencommon

```
[ 71%] Building CXX object eden/common/utils/test/CMakeFiles/utils_test.dir/ImmediateFutureTest.cpp.o
In file included from /usr/include/fb303/ThreadLocalStats-inl.h:21,
                 from /usr/include/fb303/ThreadLocalStats.h:959,
                 from /usr/include/fb303/ThreadLocalStatsMap.h:21,
                 from /usr/include/fb303/ThreadCachedServiceData.h:34,
                 from /usr/include/fb303/detail/QuantileStatWrappers.h:24,
                 from /home/builder/pkg_builds/build-edencommon-b317d57b/src/edencommon-2025.09.22.00/eden/common/telemetry/StatsGroup.h:12,
                 from /home/builder/pkg_builds/build-edencommon-b317d57b/src/edencommon-2025.09.22.00/eden/common/telemetry/StatsGroup.cpp:8:
/usr/include/fb303/TimeseriesExporter.h: In static member function ‘static void facebook::fb303::TimeseriesExporter::getCounterName(char*, int, const MLTS*, folly::StringPiece, facebook::fb303::ExportType, int)’:
/usr/include/fb303/TimeseriesExporter.h:98:27: error: ‘duration_cast’ was not declared in this scope; did you mean ‘std::chrono::duration_cast’? [-Wtemplate-body]
   98 |       auto durationSecs = duration_cast<std::chrono::seconds>(duration);
      |                           ^~~~~~~~~~~~~
      |                           std::chrono::duration_cast
In file included from /usr/include/c++/15.2.1/chrono:45,
                 from /usr/include/fb303/detail/QuantileStatWrappers.h:19:
/usr/include/c++/15.2.1/bits/chrono.h:279:7: note: ‘std::chrono::duration_cast’ declared here
  279 |       duration_cast(const duration<_Rep, _Period>& __d)
      |       ^~~~~~~~~~~~~
/usr/include/fb303/TimeseriesExporter.h:98:61: error: expected primary-expression before ‘>’ token [-Wtemplate-body]
   98 |       auto durationSecs = duration_cast<std::chrono::seconds>(duration);
      |                                                             ^
In file included from /usr/include/fb303/SimpleLRUMap.h:24,
                 from /usr/include/fb303/ThreadCachedServiceData.h:33:
/usr/include/fb303/TimeseriesExporter.h:99:7: error: expected ‘(’ before ‘>’ token [-Wtemplate-body]
   99 |       DCHECK(duration_cast<typename MLTS::Duration>(durationSecs) == duration);
      |       ^~~~~~
      ```