### PR TITLE
Update futures family to 0.3.32

### DIFF
--- a/fb303/thrift/rust/Cargo.toml
+++ b/fb303/thrift/rust/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 cpp = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_derive = "1.0.185"

--- a/fb303/thrift/rust/clients/Cargo.toml
+++ b/fb303/thrift/rust/clients/Cargo.toml
@@ -23,7 +23,7 @@ cpp = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.
 cpp_clients = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 fb303_core__types = { package = "fb303_core", version = "0.0.0", path = ".." }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 thrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 thrift_clients = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/fb303/thrift/rust/gen_safe_patch/Cargo.toml
+++ b/fb303/thrift/rust/gen_safe_patch/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 cpp = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 rust = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/fb303/thrift/rust/gen_safe_patch/clients/Cargo.toml
+++ b/fb303/thrift/rust/gen_safe_patch/clients/Cargo.toml
@@ -22,7 +22,7 @@ codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/fac
 cpp = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 cpp_clients = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 gen_safe_patch_fb303_core__types = { package = "gen_safe_patch_fb303_core", version = "0.0.0", path = ".." }
 rust = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 rust_clients = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }

--- a/fb303/thrift/rust/gen_safe_patch/mocks/Cargo.toml
+++ b/fb303/thrift/rust/gen_safe_patch/mocks/Cargo.toml
@@ -23,7 +23,7 @@ cpp = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.
 cpp_clients = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 cpp_mocks = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 gen_safe_patch_fb303_core__clients = { package = "gen_safe_patch_fb303_core_clients", version = "0.0.0", path = "../clients" }
 gen_safe_patch_fb303_core__types = { package = "gen_safe_patch_fb303_core", version = "0.0.0", path = ".." }
 rust = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }

--- a/fb303/thrift/rust/gen_safe_patch/services/Cargo.toml
+++ b/fb303/thrift/rust/gen_safe_patch/services/Cargo.toml
@@ -22,7 +22,7 @@ codegen_includer_proc_macro = { version = "0.1.0", git = "https://github.com/fac
 cpp = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 cpp_services = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 gen_safe_patch_fb303_core__types = { package = "gen_safe_patch_fb303_core", version = "0.0.0", path = ".." }
 rust = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 rust_services = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }

--- a/fb303/thrift/rust/mocks/Cargo.toml
+++ b/fb303/thrift/rust/mocks/Cargo.toml
@@ -25,7 +25,7 @@ cpp_mocks = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbt
 fb303_core__clients = { package = "fb303_core_clients", version = "0.0.0", path = "../clients" }
 fb303_core__types = { package = "fb303_core", version = "0.0.0", path = ".." }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 thrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 thrift_clients = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 thrift_mocks = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }

--- a/fb303/thrift/rust/services/Cargo.toml
+++ b/fb303/thrift/rust/services/Cargo.toml
@@ -23,7 +23,7 @@ cpp = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.
 cpp_services = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 fb303_core__types = { package = "fb303_core", version = "0.0.0", path = ".." }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 thrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 thrift_services = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }


### PR DESCRIPTION
Summary: Update the futures family of Rust crates from 0.3.30/0.3.31 to 0.3.32: futures, futures-channel, futures-core, and futures-util. This is a minor version bump that includes upstream bug fixes and improvements.

Reviewed By: dtolnay

Differential Revision: D93684256
