### PR TITLE
refactor: Remove function_scheduler shim from xplat/folly/experimental (#75)

### DIFF
--- a/fb303/BUCK
+++ b/fb303/BUCK
@@ -102,7 +102,7 @@ cpp_library(
     exported_deps = [
         ":base_service",
         "//folly/container:f14_hash",
-        "//folly/experimental:function_scheduler",
+        "//folly/executors:function_scheduler",
         "//thrift/lib/cpp:event_handler_base",
     ],
 )
@@ -230,7 +230,7 @@ cpp_library(
         "//folly:synchronized",
         "//folly:thread_local",
         "//folly/container:f14_hash",
-        "//folly/experimental:function_scheduler",
+        "//folly/executors:function_scheduler",
         "//folly/hash:rapidhash",
         "//folly/lang:align",
         "//folly/synchronization:call_once",

--- a/fb303/TFunctionStatHandler.h
+++ b/fb303/TFunctionStatHandler.h
@@ -18,7 +18,7 @@
 
 #include <fb303/BaseService.h>
 #include <folly/container/F14Map.h>
-#include <folly/experimental/FunctionScheduler.h>
+#include <folly/executors/FunctionScheduler.h>
 #include <thrift/lib/cpp/TProcessor.h>
 
 #include <string_view>

--- a/fb303/ThreadCachedServiceData.h
+++ b/fb303/ThreadCachedServiceData.h
@@ -40,7 +40,7 @@
 #include <folly/Synchronized.h>
 #include <folly/ThreadLocal.h>
 #include <folly/container/F14Map.h>
-#include <folly/experimental/FunctionScheduler.h>
+#include <folly/executors/FunctionScheduler.h>
 #include <folly/hash/rapidhash.h>
 #include <folly/lang/Align.h>
 #include <folly/synchronization/CallOnce.h>


### PR DESCRIPTION
Summary:

X-link: https://github.com/prestodb/presto/pull/27469

X-link: https://github.com/facebookincubator/velox/pull/16969

Folly/experimental is just shims to the real code, rewriting all these references.

#force_dangling_check

== NO RELEASE NOTE ==

Reviewed By: grumeta

Differential Revision: D97588319


